### PR TITLE
upgrade lego to v2.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/cloudflare/cloudflare-go v0.0.0-20190102215809-0c85496d8730 // indirect
 	github.com/ericchiang/k8s v1.2.0
-	github.com/go-acme/lego v2.4.0+incompatible
+	github.com/go-acme/lego v2.5.0+incompatible
 	github.com/golang/protobuf v0.0.0-20170307001533-c9c7427a2a70 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/miekg/dns v0.0.0-20170321070331-25ac7f171497 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ericchiang/k8s v1.2.0 h1:vxrMwEzY43oxu8aZyD/7b1s8tsBM+xoUoxjWECWFbPI=
 github.com/ericchiang/k8s v1.2.0/go.mod h1:/OmBgSq2cd9IANnsGHGlEz27nwMZV2YxlpXuQtU3Bz4=
-github.com/go-acme/lego v2.4.0+incompatible h1:+BTLUfLtDc5qQauyiTCXH6lupEUOCvXyGlEjdeU0YQI=
-github.com/go-acme/lego v2.4.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
+github.com/go-acme/lego v2.5.0+incompatible h1:5fNN9yRQfv8ymH3DSsxla+4aYeQt2IgfZqHKVnK8f0s=
+github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/golang/protobuf v0.0.0-20170307001533-c9c7427a2a70 h1:WKo1/VPcI3cbJwnIHISxazgDxbw+UIrktU3zNxzcp4c=
 github.com/golang/protobuf v0.0.0-20170307001533-c9c7427a2a70/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=

--- a/vendor/github.com/go-acme/lego/acme/api/internal/secure/jws.go
+++ b/vendor/github.com/go-acme/lego/acme/api/internal/secure/jws.go
@@ -6,7 +6,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	"github.com/go-acme/lego/acme/api/internal/nonces"
@@ -118,9 +117,6 @@ func (j *JWS) GetKeyAuthorization(token string) (string, error) {
 
 	// Generate the Key Authorization for the challenge
 	jwk := &jose.JSONWebKey{Key: publicKey}
-	if jwk == nil {
-		return "", errors.New("could not generate JWK from key")
-	}
 
 	thumbBytes, err := jwk.Thumbprint(crypto.SHA256)
 	if err != nil {

--- a/vendor/github.com/go-acme/lego/acme/api/internal/sender/useragent.go
+++ b/vendor/github.com/go-acme/lego/acme/api/internal/sender/useragent.go
@@ -5,7 +5,7 @@ package sender
 
 const (
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "xenolf-acme/2.4.0"
+	ourUserAgent = "xenolf-acme/2.5.0"
 
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release

--- a/vendor/github.com/go-acme/lego/certificate/certificates.go
+++ b/vendor/github.com/go-acme/lego/certificate/certificates.go
@@ -114,6 +114,7 @@ func (c *Certifier) Obtain(request ObtainRequest) (*Resource, error) {
 	err = c.resolver.Solve(authz)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
+		c.deactivateAuthorizations(order)
 		return nil, err
 	}
 
@@ -170,6 +171,7 @@ func (c *Certifier) ObtainForCSR(csr x509.CertificateRequest, bundle bool) (*Res
 	err = c.resolver.Solve(authz)
 	if err != nil {
 		// If any challenge fails, return. Do not generate partial SAN certificates.
+		c.deactivateAuthorizations(order)
 		return nil, err
 	}
 

--- a/vendor/github.com/go-acme/lego/providers/dns/cloudflare/cloudflare.toml
+++ b/vendor/github.com/go-acme/lego/providers/dns/cloudflare/cloudflare.toml
@@ -2,6 +2,7 @@ Name = "Cloudflare"
 Description = ''''''
 URL = "https://www.cloudflare.com/dns/"
 Code = "cloudflare"
+Since = "v0.3.0"
 
 Example = '''
 CLOUDFLARE_EMAIL=foo@bar.com \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/ericchiang/k8s/apis/apiextensions/v1beta1
 github.com/ericchiang/k8s/apis/resource
 github.com/ericchiang/k8s/runtime/schema
 github.com/ericchiang/k8s/util/intstr
-# github.com/go-acme/lego v2.4.0+incompatible
+# github.com/go-acme/lego v2.5.0+incompatible
 github.com/go-acme/lego/certificate
 github.com/go-acme/lego/lego
 github.com/go-acme/lego/providers/dns/cloudflare


### PR DESCRIPTION
Doesn't bring us anything new we need, but I'd like to keep it up to date anyway.

See https://github.com/go-acme/lego/releases/tag/v2.5.0