### PR TITLE
use background context instead

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 	// parse command line parameters
 	kingpin.Parse()
 
-	var ctx context.Context
+	ctx := context.Background()
 	// init log format from envvar ESTAFETTE_LOG_FORMAT
 	foundation.InitLoggingFromEnv(foundation.NewApplicationInfo(appgroup, app, version, branch, revision, buildDate))
 


### PR DESCRIPTION
Using cancellable context can be problematic for the long running process. It panics, so the pod is constantly in _CrashLoopBackOff_ loop. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x12deb06]

goroutine 35 [running]:
k8s.io/client-go/rest.(*withRetry).Before(0xc00044ad40, {0x0, 0x0}, 0xc000266000)
	/go/pkg/mod/k8s.io/client-go@v0.25.4/rest/with_retry.go:194 +0x46
k8s.io/client-go/rest.(*Request).Watch(0xc000266000, {0x0, 0x0})
	/go/pkg/mod/k8s.io/client-go@v0.25.4/rest/request.go:711 +0xff
k8s.io/client-go/kubernetes/typed/core/v1.(*secrets).Watch(0xc0001bb860, {0x0, 0x0}, {{{0x0, 0x0}, {0x0, 0x0}}, {0x0, 0x0}, {0x0, ...}, ...})
	/go/pkg/mod/k8s.io/client-go@v0.25.4/kubernetes/typed/core/v1/secret.go:112 +0x146
main.watchSecrets({0x0, 0x0}, 0x0?, 0xc000210c00)
	/estafette-work/main.go:147 +0x1b8
created by main.main
	/estafette-work/main.go:131 +0x345
```

To address this, `context.Background()` should be used.  Fixes #46 