### PR TITLE
retrieve dns zone backwards instead

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -58,47 +58,29 @@ func (cf *Cloudflare) GetZoneByDNSName(dnsName string) (r Zone, err error) {
 		return
 	}
 
-	// start taking parts from the end of dnsName and see if cloudflare has a zone for them
-	numberOfZoneItems := 2
-	zoneNameParts, err := getLastItemsFromSlice(dnsNameParts, numberOfZoneItems)
-	if err != nil {
-		return r, err
-	}
-
-	zoneName := strings.Join(zoneNameParts, ".")
-	zonesResult, err := cf.getZonesByName(zoneName)
-	if err != nil {
-		return r, err
-	}
-
-	// if matching zones results fit in a single page get the fully matching zone from the results, otherwise narrow down the search
-	if (zonesResult.ResultInfo.Count > 0) && (zonesResult.ResultInfo.Count <= zonesResult.ResultInfo.PerPage) {
-		r, err = getMatchingZoneFromZones(zonesResult.Zones, zoneName)
-		return
-	}
-
 	// if too many zones or none exist for last 2 parts of the dns name, we have to narrow down the search by specifying a more detailed name
-	for ((zonesResult.ResultInfo.TotalCount == 0) || (zonesResult.ResultInfo.TotalCount > zonesResult.ResultInfo.PerPage)) && (numberOfZoneItems < len(dnsNameParts)) {
-		numberOfZoneItems++
-		zoneNameParts, err = getLastItemsFromSlice(dnsNameParts, numberOfZoneItems)
+	numberOfZoneItems := len(dnsNameParts)
+	for numberOfZoneItems > 1 {
+		zoneNameParts, err := getLastItemsFromSlice(dnsNameParts, numberOfZoneItems)
 		if err != nil {
-			return
+			return r, err
 		}
 
-		zoneName = strings.Join(zoneNameParts, ".")
-		zonesResult, err = cf.getZonesByName(zoneName)
+		zoneName := strings.Join(zoneNameParts, ".")
+		zonesResult, err := cf.getZonesByName(zoneName)
 		if err != nil {
-			return
+			return r, err
 		}
 
 		if (zonesResult.ResultInfo.Count > 0) && (zonesResult.ResultInfo.Count <= zonesResult.ResultInfo.PerPage) {
-			r, err = getMatchingZoneFromZones(zonesResult.Zones, zoneName)
-			return
+			r, err := getMatchingZoneFromZones(zonesResult.Zones, zoneName)
+			return r, err
 		}
+		numberOfZoneItems--
 	}
 
 	err = errors.New("cloudflare: no matching zone has been found")
-	return
+	return r, err
 }
 
 func (cf *Cloudflare) getSSLConfigurationByZone(zone Zone) (r listResult, err error) {


### PR DESCRIPTION
It is way better to assign DNS records in a subdomain than a root.

If we have a new DNS record that we want to introduce, named `foo.bar.example.com`, it is better for the service to look for a subdomain first. This means it will check if `foo.bar.example.com` exists and if it does, it will assign the DNS record to that subdomain. If not, if will look for `bar.example.com` and then for `example.com`.

In the current logic it is the other way around. If `example.com` exists, then it will be assigned to that one. It will ignore any subdomains.